### PR TITLE
Move to astropy affiliate package template.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,9 +15,18 @@ Organization
 
 - root
 
+  - specview: Initial package.
   - proto: Prototype, pre-sprint, or other code used as reference material.
 
+Development
+-----------
+
+Whether or not this code base will become an astropy affiliate
+package, the current framework as been placed under the
+`package-template` using the `managing the template files via git`
+method.
 
 .. _JWST Data Analysis Task Force: https://confluence.stsci.edu/display/JWSTDATF/JWST+Data+Analysis+Task+Force+Home
 .. _JWST Data Analysis Forum: https://confluence.stsci.edu/display/JWSTDATF/JWST+Data+Analysis+Development+Forum
-
+.. _package-template: https://github.com/astropy/package-template
+.. _managing the template files via git: http://astropy.readthedocs.org/en/latest/development/affiliated-packages.html#managing-the-template-files-via-git

--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ Development
 
 Whether or not this code base will become an astropy affiliate
 package, the current framework as been placed under the
-`package-template` using the `managing the template files via git`
+`package-template`_ using the `managing the template files via git`_
 method.
 
 .. _JWST Data Analysis Task Force: https://confluence.stsci.edu/display/JWSTDATF/JWST+Data+Analysis+Task+Force+Home


### PR DESCRIPTION
The package has been moved into using the astropy affiliate template. The move has already happened; this PR is to document that and update the README.

If there is issue with this, the original package structure can be found in the pre-affiliate branch.
