### PR TITLE
Encorporate IPython console

### DIFF
--- a/specview/main.py
+++ b/specview/main.py
@@ -3,7 +3,7 @@
 from os import sys
 
 from .ui.controller import Controller
-from .ui.ipython.kernel import ipython_inprocess_kernel_start
+from .ui.ipython.kernel import ipython_kernel_start
 
 class SView(Controller):
     """Main entry point"""
@@ -16,7 +16,7 @@ class SView(Controller):
         if self.__class__.qt_app is None:
             self.__class__.qt_app = pyqtapplication(argv)
 
-        self.kernel = ipython_inprocess_kernel_start()
+        self.kernel = ipython_kernel_start()
         super(SView, self).__init__(argv)
         self.viewer.show()
 

--- a/specview/main.py
+++ b/specview/main.py
@@ -2,8 +2,8 @@
 
 from os import sys
 
-from specview.ui.controller import Controller
-
+from .ui.controller import Controller
+from .ui.ipython.kernel import ipython_inprocess_kernel_start
 
 class SView(Controller):
     """Main entry point"""
@@ -16,6 +16,7 @@ class SView(Controller):
         if self.__class__.qt_app is None:
             self.__class__.qt_app = pyqtapplication(argv)
 
+        self.kernel = ipython_inprocess_kernel_start()
         super(SView, self).__init__(argv)
         self.viewer.show()
 

--- a/specview/ui/controller.py
+++ b/specview/ui/controller.py
@@ -92,6 +92,11 @@ class Controller(object):
         self.model.sig_added_item.connect(self._update_namespace)
         self.model.sig_removed_item.connect(self._update_namespace)
 
+        self.viewer.console_dock.wgt_console.kernel_manager = self.kernel['manager']
+        self.viewer.console_dock.wgt_console.kernel_client = self.kernel['client']
+        self.viewer.console_dock.wgt_console.kernel = self.kernel['kernel']
+        self.viewer.console_dock.wgt_console.exit_requested.connect(self.kernel['shutdown'])
+
     # -- protected functions
     def _create_display(self):
         item = self.viewer.data_dock.wgt_data_tree.current_item
@@ -304,3 +309,4 @@ class Controller(object):
                     layer_item.item
 
         self.viewer.console_dock.wgt_console.localNamespace = local_namespace
+        self.viewer.console_dock.wgt_console.kernel.shell.push(local_namespace)

--- a/specview/ui/controller.py
+++ b/specview/ui/controller.py
@@ -94,10 +94,9 @@ class Controller(object):
         self.model.sig_added_item.connect(self._update_namespace)
         self.model.sig_removed_item.connect(self._update_namespace)
 
-        self.viewer.console_dock.wgt_console.kernel_manager = self.kernel['manager']
+        self.viewer.console_dock.wgt_console.kernel_manager = getattr(self.kernel, 'manager', None)
         self.viewer.console_dock.wgt_console.kernel_client = self.kernel['client']
-        self.viewer.console_dock.wgt_console.kernel = self.kernel['kernel']
-        self.viewer.console_dock.wgt_console.exit_requested.connect(self.kernel['shutdown'])
+        self.viewer.console_dock.wgt_console.shell = self.kernel['shell']
 
     # -- protected functions
     def _create_display(self):
@@ -311,4 +310,4 @@ class Controller(object):
                     layer_item.item
 
         self.viewer.console_dock.wgt_console.localNamespace = local_namespace
-        self.viewer.console_dock.wgt_console.kernel.shell.push(local_namespace)
+        self.viewer.console_dock.wgt_console.shell.push(local_namespace)

--- a/specview/ui/controller.py
+++ b/specview/ui/controller.py
@@ -38,9 +38,11 @@ class Controller(object):
                                  'divide': lambda x, y: self.add_data_set(
                                      x / y),
                                  'multiple': lambda x, y: self.add_data_set(
-                                     x * y)}
+                                     x * y),
+                                 'add_data_set': self.add_data_set}
 
-        self._viewer.console_dock.wgt_console.localNamespace = self._main_name_space
+        #self._viewer.console_dock.wgt_console.localNamespace = self._main_name_space
+        self._update_namespace()
 
         try:
             if len(argv) > 1:

--- a/specview/ui/controller.py
+++ b/specview/ui/controller.py
@@ -15,7 +15,7 @@ class Controller(object):
     def __init__(self, argv):
         super(Controller, self).__init__()
         self._model = SpectrumDataTreeModel()
-        self._viewer = MainWindow()
+        self._viewer = MainWindow(show_console=self.kernel['client'] is not None)
         self._viewer.data_dock.wgt_data_tree.setModel(self._model)
         self._viewer.model_editor_dock.wgt_model_tree.setModel(self._model)
 

--- a/specview/ui/ipython/kernel.py
+++ b/specview/ui/ipython/kernel.py
@@ -56,10 +56,15 @@ def connected_kernel(**kwargs):
     if shell is None:
         raise RuntimeError("There is no IPython kernel in this process")
 
-    client = QtKernelClient(connection_file=get_connection_file())
-    client.load_connection_file()
-    client.start_channels()
-    kernel_info['client'] = client
+    try:
+        client = QtKernelClient(connection_file=get_connection_file())
+        client.load_connection_file()
+        client.start_channels()
+        kernel_info['client'] = client
+    except Exception:
+        print 'Cannot connect to client. Just using the command line.'
+        kernel_info['client'] = None
+        pass
     kernel_info['shell'] = shell
 
     return kernel_info

--- a/specview/ui/ipython/kernel.py
+++ b/specview/ui/ipython/kernel.py
@@ -1,0 +1,27 @@
+"""Start and IPython kernel"""
+from IPython.qt.inprocess import QtInProcessKernelManager
+
+
+def ipython_inprocess_kernel_start():
+    # Create an in-process kernel
+    # >>> print_process_id()
+    # will print the same process ID as the main process
+    kernel_manager = QtInProcessKernelManager()
+    kernel_manager.start_kernel()
+    kernel = kernel_manager.kernel
+    kernel.gui = 'qt4'
+
+    kernel_client = kernel_manager.client()
+    kernel_client.start_channels()
+
+    def stop():
+        kernel_client.stop_channels()
+        kernel_manager.shutdown_kernel()
+
+    kernel_info = {
+        'kernel': kernel,
+        'manager': kernel_manager,
+        'client':  kernel_client,
+        'shutdown': stop
+    }
+    return kernel_info

--- a/specview/ui/ipython/kernel.py
+++ b/specview/ui/ipython/kernel.py
@@ -4,8 +4,6 @@ from IPython.qt.inprocess import QtInProcessKernelManager
 
 def ipython_inprocess_kernel_start():
     # Create an in-process kernel
-    # >>> print_process_id()
-    # will print the same process ID as the main process
     kernel_manager = QtInProcessKernelManager()
     kernel_manager.start_kernel()
     kernel = kernel_manager.kernel

--- a/specview/ui/qt/docks.py
+++ b/specview/ui/qt/docks.py
@@ -173,7 +173,6 @@ class ConsoleDockWidget(BaseDockWidget):
 
         self.setAllowedAreas(QtCore.Qt.BottomDockWidgetArea)
 
-        #self.wgt_console = ConsoleWidget()
         self.wgt_console = RichIPythonWidget()
 
         self.add_widget(self.wgt_console)

--- a/specview/ui/qt/docks.py
+++ b/specview/ui/qt/docks.py
@@ -2,6 +2,7 @@ from os import sys, path
 
 from ...external.qt import QtGui, QtCore
 from pyqtgraph.console import ConsoleWidget
+from IPython.qt.console.rich_ipython_widget import RichIPythonWidget
 
 from specview.ui.qt.boxes import StatisticsGroupBox
 from specview.ui.qt.tree_views import SpectrumDataTree, ModelTree
@@ -172,7 +173,8 @@ class ConsoleDockWidget(BaseDockWidget):
 
         self.setAllowedAreas(QtCore.Qt.BottomDockWidgetArea)
 
-        self.wgt_console = ConsoleWidget()
+        #self.wgt_console = ConsoleWidget()
+        self.wgt_console = RichIPythonWidget()
 
         self.add_widget(self.wgt_console)
 

--- a/specview/ui/viewer.py
+++ b/specview/ui/viewer.py
@@ -7,9 +7,10 @@ from specview.ui.qt.docks import (DataDockWidget, MeasurementDockWidget,
 
 
 class MainWindow(QtGui.QMainWindow):
-    def __init__(self):
+    def __init__(self, show_console=True):
         super(MainWindow, self).__init__()
         # Basic app info
+        self.show_console = show_console
         self.menu_bar = MainMainBar()
         self.setMenuBar(self.menu_bar)
         self.setWindowTitle('SpecPy')
@@ -72,8 +73,9 @@ class MainWindow(QtGui.QMainWindow):
             self.measurement_dock.toggleViewAction())
         # self.menu_bar.docks_menu.addAction(
         #     self.equiv_width_dock.toggleViewAction())
-        self.menu_bar.window_menu.addAction(
-            self.console_dock.toggleViewAction())
+        if self.show_console:
+            self.menu_bar.window_menu.addAction(
+                self.console_dock.toggleViewAction())
 
     def set_toolbar(self, toolbar=None, hide_all=False):
         if toolbar is not None:


### PR DESCRIPTION
Address the 'future' in issue #32 of using an IPython console.
Also groundwork set for using specview from an existing interpreter.
